### PR TITLE
Enable serial output for parking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # DIT2025
 
 A smart vehicle parking management system that monitors and organizes parking spaces using sensor-based input and a web dashboard. Offers an interactive front-end (index.html) for real-time status viewing.
+
+## Serial Output
+
+The application can emit JSON messages over a serial port whenever a vehicle
+enters or leaves the parking lot. The format of the message is:
+
+```json
+{
+  "plate": "T898SBR",
+  "action": 1,       // 1 for entering, 0 for leaving
+  "slots": 3,        // total number of slots
+  "used": 2          // currently occupied slots
+}
+```
+
+Serial parameters can be configured using environment variables:
+
+- `SERIAL_PORT` – device path (default `/dev/ttyUSB0`)
+- `SERIAL_BAUD` – baud rate (default `9600`)
+
+If a serial port cannot be opened, the JSON message is printed to the server
+console instead.

--- a/app.py
+++ b/app.py
@@ -1,10 +1,51 @@
-from flask import Flask, send_from_directory
+from flask import Flask, send_from_directory, request, jsonify
+import os
+import json
+try:
+    import serial
+except ImportError:  # Serial not installed, runtime will fail if used
+    serial = None
+
+SERIAL_PORT = os.environ.get("SERIAL_PORT", "/dev/ttyUSB0")
+SERIAL_BAUD = int(os.environ.get("SERIAL_BAUD", "9600"))
+serial_conn = None
 
 app = Flask(__name__, static_folder=".")
+
+
+def get_serial_connection():
+    """Initialise serial connection if possible."""
+    global serial_conn
+    if serial_conn is not None:
+        return serial_conn
+    if serial is None:
+        return None
+    try:
+        serial_conn = serial.Serial(SERIAL_PORT, SERIAL_BAUD, timeout=1)
+    except Exception as e:
+        print(f"Could not open serial port {SERIAL_PORT}: {e}")
+        serial_conn = None
+    return serial_conn
 
 @app.route('/')
 def index():
     return send_from_directory(app.static_folder, 'index.html')
+
+
+@app.route('/serial_event', methods=['POST'])
+def serial_event():
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'status': 'error', 'message': 'Invalid JSON'}), 400
+    ser = get_serial_connection()
+    if ser:
+        try:
+            ser.write((json.dumps(data) + '\n').encode('utf-8'))
+        except Exception as e:
+            print(f'Error writing to serial port: {e}')
+    else:
+        print('Serial output:', json.dumps(data))
+    return jsonify({'status': 'ok'})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/index.html
+++ b/index.html
@@ -212,6 +212,19 @@
             }
         }
 
+        function sendSerialData(plate, isEntering) {
+            fetch('/serial_event', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    plate: plate,
+                    action: isEntering ? 1 : 0,
+                    slots: MAX_PARKING_CAPACITY,
+                    used: carsInParking.size
+                })
+            }).catch(err => console.error('Serial send error:', err));
+        }
+
         function processOcrResult(text) {
             const plateData = findPlateInDB(text);
             if (plateData) {
@@ -229,6 +242,7 @@
                     carsInParking.add(plateData.plate);
                 }
                 updateParkingCount();
+                sendSerialData(plateData.plate, parkingStatus === 'Entering');
                 lastPlateData = plateData;
                 outputDisplay.innerHTML = formatPlateDetails(plateData, parkingStatus);
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+pyserial


### PR DESCRIPTION
## Summary
- emit JSON messages over a serial port when vehicles enter or leave
- call new `/serial_event` endpoint from the web UI
- document serial output and update dependencies

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py` (server startup verified)

------
https://chatgpt.com/codex/tasks/task_e_6846ae7e7e208331bddd7d2ec7ed472b